### PR TITLE
Enabling memory_resources to be created from resource_views

### DIFF
--- a/include/cuda/memory_resource
+++ b/include/cuda/memory_resource
@@ -63,6 +63,17 @@ namespace memory_kind {
    * \brief Virtual memory that is automatically migrated between the host and devices.
    */
   struct managed;
+  
+  /*!
+   * \brief General kind for wrapping views
+   */
+  template <typename... Properties>
+  struct with_properties
+  {
+    template <typename Property>
+    struct contains : std::bool_constant<(std::is_same<Property, Properties>{} || ...)>{};
+  };
+  
 };
 
 namespace detail {
@@ -696,6 +707,10 @@ struct is_kind;
 
 template <typename _MemoryKind>
 struct kind_has_property<_MemoryKind, is_kind<_MemoryKind>> : _CUDA_VSTD::true_type {};
+
+template <typename P, typename... Properties>
+struct kind_has_property<memory_kind::with_properties<Properties...>, P>
+  : memory_kind::with_properties<Properties...>::template contains<P> {};
 
 #define _LIBCUDACXX_MEMORY_KIND_PROPERTY(__kind, __property)\
 template <> struct kind_has_property<__kind, __property> : _CUDA_VSTD::true_type {};

--- a/include/cuda/memory_resource
+++ b/include/cuda/memory_resource
@@ -43,6 +43,9 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
  *
  * This is not a closed set, the user code can define custom memory kinds.
  */
+
+struct any_memory {};
+
 namespace memory_kind {
   /*!
    * \brief Ordinary host memory
@@ -126,7 +129,7 @@ class basic_resource_view;
 template <typename... _Properties>
 struct properties;
 
-
+#if 0
 namespace detail {
   template <typename... _Properties>
   struct __kind_from_properties_helper {
@@ -159,7 +162,7 @@ struct kind_from_properties {
     detail::__kind_from_properties_helper_t<_Properties...>
   >;
 };
-
+#endif
 
 /*!
  * \brief Groups the tag types denoting the execution environment in which the memory can be accessed
@@ -715,19 +718,23 @@ struct kind_has_property<memory_kind::with_properties<Properties...>, P>
 #define _LIBCUDACXX_MEMORY_KIND_PROPERTY(__kind, __property)\
 template <> struct kind_has_property<__kind, __property> : _CUDA_VSTD::true_type {};
 
+_LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::host, any_memory);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::host, memory_access::host);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::host, oversubscribable);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::host, memory_location::host);
 
+_LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, any_memory);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, memory_access::host);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, memory_access::device);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, resident);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, memory_location::host);
 
+_LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::device, any_memory);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::device, memory_access::device);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::device, resident);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::device, memory_location::device);
 
+_LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::managed, any_memory);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::managed, memory_access::host);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::managed, memory_access::device);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::managed, oversubscribable);

--- a/include/cuda/memory_resource
+++ b/include/cuda/memory_resource
@@ -43,9 +43,6 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
  *
  * This is not a closed set, the user code can define custom memory kinds.
  */
-
-struct any_memory {};
-
 namespace memory_kind {
   /*!
    * \brief Ordinary host memory
@@ -718,23 +715,19 @@ struct kind_has_property<memory_kind::with_properties<Properties...>, P>
 #define _LIBCUDACXX_MEMORY_KIND_PROPERTY(__kind, __property)\
 template <> struct kind_has_property<__kind, __property> : _CUDA_VSTD::true_type {};
 
-_LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::host, any_memory);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::host, memory_access::host);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::host, oversubscribable);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::host, memory_location::host);
 
-_LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, any_memory);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, memory_access::host);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, memory_access::device);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, resident);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::pinned, memory_location::host);
 
-_LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::device, any_memory);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::device, memory_access::device);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::device, resident);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::device, memory_location::device);
 
-_LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::managed, any_memory);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::managed, memory_access::host);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::managed, memory_access::device);
 _LIBCUDACXX_MEMORY_KIND_PROPERTY(memory_kind::managed, oversubscribable);
@@ -934,7 +927,7 @@ bool operator!=(const memory_resource<_Kind> *__mr, const basic_resource_view<_R
 }
 
 template <typename... _Properties>
-using resource_view = basic_resource_view<detail::memory_resource_base*, any_memory, _Properties...>;
+using resource_view = basic_resource_view<detail::memory_resource_base*, _Properties...>;
 
 template <typename... _Properties>
 using stream_ordered_resource_view = basic_resource_view<detail::stream_ordered_memory_resource_base*, _Properties...>;

--- a/include/cuda/memory_resource
+++ b/include/cuda/memory_resource
@@ -934,7 +934,7 @@ bool operator!=(const memory_resource<_Kind> *__mr, const basic_resource_view<_R
 }
 
 template <typename... _Properties>
-using resource_view = basic_resource_view<detail::memory_resource_base*, _Properties...>;
+using resource_view = basic_resource_view<detail::memory_resource_base*, any_memory, _Properties...>;
 
 template <typename... _Properties>
 using stream_ordered_resource_view = basic_resource_view<detail::stream_ordered_memory_resource_base*, _Properties...>;


### PR DESCRIPTION
If accepted, please perform a squash on merge to remove the intermediate commits.

I toyed around with `any_memory` which I didn't pan out.

Unfortunately, f9d7d348ab545dd1291a112273308aac231a050c has a necessary commit to both disable some broken code and to add `any_memory`